### PR TITLE
New accept_header_response

### DIFF
--- a/annoying/decorators.py
+++ b/annoying/decorators.py
@@ -7,7 +7,7 @@ from django.utils import simplejson
 
 import datetime
 
-__all__ = ['render_to', 'signals', 'ajax_request', 'autostrip', 'accept_header_response']
+__all__ = ['render_to', 'signals', 'ajax_request', 'autostrip']
 
 
 try:


### PR DESCRIPTION
I've added a new decorator that I find quite useful in a number of situations (particularly when writing APIs etc).

Similar to the ajax_response decorator, in that it takes a dictionary or list returned from the view, but it will try and format the response in a way that matches the HTTP "Accept:" header. Currently supports YAML and JSON, but is very easily extensible.
