### PR TITLE
Allow serialisation of anything except HttpResponse subclasses

### DIFF
--- a/annoying/decorators.py
+++ b/annoying/decorators.py
@@ -188,7 +188,7 @@ def ajax_request(func):
         else:
             format_type = 'application/json'
         response = func(request, *args, **kwargs)
-        if isinstance(response, dict) or isinstance(response, list):
+        if not isinstance(response, HttpResponse):
             data = FORMAT_TYPES[format_type](response)
             response = HttpResponse(data, content_type=format_type)
             response['content-length'] = len(data)


### PR DESCRIPTION
Sorry, thought of something else!

Why limit it to `list` or `dict` objects? If something is serialisable, why not let them do it?

Except for `HttpResponse` objects, of course - they should be left alone.
