### PR TITLE
Update Signals __init__ to support python3

### DIFF
--- a/annoying/decorators.py
+++ b/annoying/decorators.py
@@ -114,7 +114,7 @@ class Signals(object):
         self._signals = {}
 
         # register all Django's default signals
-        for k, v in signalmodule.__dict__.iteritems():
+        for k, v in signalmodule.__dict__.items():
             # that's hardcode, but IMHO it's better than isinstance
             if not k.startswith('__') and k != 'Signal':
                 self.register_signal(v, k)


### PR DESCRIPTION
I'm using django 1.5 with python 3.3.2, so I stuck at iteritems error. Simply, python3 no longer gives iter\* functions, it always uses iterators. So, let's just use six module to make it compatable with both python versions.
