### PR TITLE
template name convention added to render_to

### DIFF
--- a/annoying/decorators.py
+++ b/annoying/decorators.py
@@ -10,6 +10,7 @@ except ImportError:
     from django.utils import simplejson as json
 
 import datetime
+import os
 
 __all__ = ['render_to', 'signals', 'ajax_request', 'autostrip']
 
@@ -82,8 +83,8 @@ def render_to(template=None, mimetype=None):
                 return output
             tmpl = output.pop('TEMPLATE', template)
             if tmpl is None:
-                template_dir = '/'.join(function.__module__.split('.')[:-1])
-                tmpl = template_dir + '/' + function.func_name + ".html"
+                template_dir = os.path.join(*function.__module__.split('.')[:-1])
+                tmpl = os.path.join(template_dir, function.func_name + ".html")
             return render_to_response(tmpl, output, \
                         context_instance=RequestContext(request), mimetype=mimetype)
         return wrapper


### PR DESCRIPTION
This feature is easy,

If no template name is provided, then just generate a template name, based on the app name (and view subpackages) plus the view name.
