### PR TITLE
Added jsonp callback support to ajax_request decorator

### DIFF
--- a/annoying/decorators.py
+++ b/annoying/decorators.py
@@ -193,7 +193,11 @@ def ajax_request(func):
             format_type = 'application/json'
         response = func(request, *args, **kwargs)
         if not isinstance(response, HttpResponse):
-            data = FORMAT_TYPES[format_type](response)
+            callback = request.GET.get('callback')
+            if callback:
+                data = '%s(%s)' % (callback, FORMAT_TYPES[format_type](response))
+            else:
+                data = FORMAT_TYPES[format_type](response)
             response = HttpResponse(data, content_type=format_type)
             response['content-length'] = len(data)
         return response


### PR DESCRIPTION
Added support for jsonp ajax requests

Example:
```js
$.ajax({
    type: 'GET',
    dataType: "jsonp",
    url: 'http://some-url'
}).done(function(data) {
    console.log(data);
});
```