### PR TITLE
fixed incompatibility for django 1.4

### DIFF
--- a/annoying/decorators.py
+++ b/annoying/decorators.py
@@ -88,7 +88,7 @@ def render_to(template=None, content_type=None, mimetype=None):
                 template_dir = os.path.join(*function.__module__.split('.')[:-1])
                 tmpl = os.path.join(template_dir, function.func_name + ".html")
             # Explicit version check to avoid swallowing other exceptions
-            if DJANGO_VERSION[0] >= 1 and DJANGO_VERSION[1] >= 3:
+            if DJANGO_VERSION[0] >= 1 and DJANGO_VERSION[1] >= 5:
                 return render_to_response(tmpl, output, \
                         context_instance=RequestContext(request),
                         content_type=content_type or mimetype)


### PR DESCRIPTION
render_to_response in django 1.3 and 1.4 accepts only mimetype arg
