### PR TITLE
AutoOneToOneField creates objets using Manager create function

### DIFF
--- a/annoying/fields.py
+++ b/annoying/fields.py
@@ -22,7 +22,7 @@ class AutoSingleRelatedObjectDescriptor(SingleRelatedObjectDescriptor):
         try:
             return super(AutoSingleRelatedObjectDescriptor, self).__get__(instance, instance_type)
         except self.related.model.DoesNotExist:
-            obj = self.related.model(**{self.related.field.name: instance})
+            obj = self.related.model.objects.create(**{self.related.field.name: instance})
             obj.save()
             # Don't return obj directly, otherwise it won't be added
             # to Django's cache, and the first 2 calls to obj.relobj


### PR DESCRIPTION
This gives bit more control to developer when adding extra stuff on object creation.
Now I can use Custom manager with overriden create function, and do some other connections I need before I use object.

	class SubmissionManager(models.Manager):

	    def create(self, **kwargs):
	        obj = super(SubmissionManager, self).create(**kwargs)
	        CampaignModel = models.get_model('survey', 'Campaign')
	        campaign = CampaignModel.objects.get_for_user(obj.target)
	        obj.campaign = campaign
	        obj.save()
	        return obj

	class Submission(models.Model):

	    target = AutoOneToOneField('supplier.TargetUser', related_name="submission", null=True, blank=False)
	    ...
	    campaign = models.ForeignKey('survey.SurveyCampaign', related_name="submissions", null=True, blank=False)

	    legal_true_flag = models.BooleanField(default=False)
	    legal_terms = models.BooleanField(default=False)
	    legal_name_match = models.BooleanField(default=False)

	    objects = SubmissionManager()

now when I do:

    target.submission.campaign

I will have proper campaign attached to it. before I got None