### PR TITLE
changing get_db_prep_save to get_db_value

### DIFF
--- a/annoying/fields.py
+++ b/annoying/fields.py
@@ -90,12 +90,12 @@ class JSONField(models.TextField):
             pass
         return value
 
-    def get_db_prep_save(self, value, *args, **kwargs):
+    def get_prep_value(self, value):
         if value == "":
             return None
         if isinstance(value, dict) or isinstance(value, list):
             value = json.dumps(value, cls=DjangoJSONEncoder)
-        return super(JSONField, self).get_db_prep_save(value, *args, **kwargs)
+        return super(JSONField, self).get_prep_value(value)
 
     def value_from_object(self, obj):
         value = super(JSONField, self).value_from_object(obj)


### PR DESCRIPTION
I'm trying to make this field work with an EncryptedTextField I have, and realized that get_db_prep_save isn't the best place for the encoding to happen.

get_db_prep_save should be used when there's a custom database type like connection.Database.Binary or something. See here: https://docs.djangoproject.com/en/dev/howto/custom-model-fields/#converting-query-values-to-database-values

get_prep_value should be a better place to do this, and is working great for my purposes at least.

Figured I'd send a pull request in case you agreed! This will affect backwards compatibility for some.