### PR TITLE
Fix race condition in related auto-create

### DIFF
--- a/annoying/fields.py
+++ b/annoying/fields.py
@@ -40,9 +40,8 @@ class AutoSingleRelatedObjectDescriptor(SingleRelatedObjectDescriptor):
             return (super(AutoSingleRelatedObjectDescriptor, self)
                     .__get__(instance, instance_type))
         except model.DoesNotExist:
-            obj = model(**{self.related.field.name: instance})
-
-            obj.save()
+            # Using get_or_create instead() of save() or create() as it better handles race conditions
+            model.objects.get_or_create(**{self.related.field.name: instance})
 
             # Don't return obj directly, otherwise it won't be added
             # to Django's cache, and the first 2 calls to obj.relobj

--- a/annoying/tests/__init__.py
+++ b/annoying/tests/__init__.py
@@ -1,3 +1,4 @@
 """Tests for django-annoying"""
 
 from .decorators import AJAXRequestTestCase, RenderToTestCase
+from .fields import FieldsTestCase

--- a/annoying/tests/fields.py
+++ b/annoying/tests/fields.py
@@ -1,0 +1,8 @@
+from django.test import TestCase
+from . import models
+
+
+class FieldsTestCase(TestCase):
+    def test_auto_one_to_one(self):
+        super_villain = models.SuperVillain.objects.create()
+        self.assertEqual(super_villain.mortal_enemy.name, "Captain Hammer")

--- a/annoying/tests/models.py
+++ b/annoying/tests/models.py
@@ -1,0 +1,11 @@
+from django.db import models
+from annoying.fields import AutoOneToOneField
+
+
+class SuperVillain(models.Model):
+    name = models.CharField(max_length="20", default="Dr Horrible")
+
+
+class SuperHero(models.Model):
+    name = models.CharField(max_length="20", default="Captain Hammer")
+    mortal_enemy = AutoOneToOneField(SuperVillain, related_name='mortal_enemy')

--- a/test.py
+++ b/test.py
@@ -11,7 +11,8 @@ SETTINGS = dict(
     DEBUG=True,
     TEMPLATE_DEBUG=True,
     ROOT_URLCONF=this,
-    INSTALLED_APPS=('django.contrib.auth', 'django.contrib.contenttypes', 'django.contrib.sessions', 'annoying'),
+    INSTALLED_APPS=('django.contrib.auth', 'django.contrib.contenttypes', 'django.contrib.sessions',
+                    'annoying', 'annoying.tests'),
     TEMPLATE_DIRS=(osp.join(BASE_DIR, 'annoying', 'tests', 'templates'),),
 )
 


### PR DESCRIPTION
* Replace save() with get_or_create():
  In Django's internals get_or_create() will catch and handle things like
  an IntegrityError that could be caused by a race condition.
* Add a test to make sure auto-create still works after the change.