### PR TITLE
Fix not working JSONField in Django 1.9

### DIFF
--- a/annoying/fields.py
+++ b/annoying/fields.py
@@ -126,8 +126,9 @@ class JSONField(six.with_metaclass(models.SubfieldBase, models.TextField)):
         if value == "":
             return None
         if isinstance(value, dict) or isinstance(value, list):
-            value = json.dumps(value, cls=DjangoJSONEncoder)
-        return super(JSONField, self).get_db_prep_save(value, *args, **kwargs)
+            return json.dumps(value, cls=DjangoJSONEncoder)
+        else:
+            return super(JSONField, self).get_db_prep_save(value, *args, **kwargs)
 
     def value_from_object(self, obj):
         value = super(JSONField, self).value_from_object(obj)

--- a/annoying/tests/fields.py
+++ b/annoying/tests/fields.py
@@ -1,8 +1,47 @@
+import json
+
 from django.test import TestCase
 from . import models
+
+
+def dump_dict(d):
+    """
+    Returns a JSON string sorted by keys
+    """
+    return json.dumps(d, sort_keys=True)
 
 
 class FieldsTestCase(TestCase):
     def test_auto_one_to_one(self):
         super_villain = models.SuperVillain.objects.create()
         self.assertEqual(super_villain.mortal_enemy.name, "Captain Hammer")
+
+    def test_json_field_create(self):
+        stats = {
+            'strength': 100,
+            'defence': 50,
+        }
+        super_villain = models.SuperVillain.objects.create(stats=stats)
+
+        # Refresh from DB
+        super_villain = models.SuperVillain.objects.get(pk=super_villain.pk)
+
+        self.assertEqual(super_villain.stats['strength'], 100)
+        self.assertEqual(super_villain.stats['defence'], 50)
+        self.assertEqual(dump_dict(super_villain.stats), dump_dict(stats))
+
+    def test_json_field_update(self):
+        super_villain = models.SuperVillain.objects.create()
+        stats = {
+            'strength': 100,
+            'defence': 50,
+        }
+        super_villain.stats = stats
+        super_villain.save()
+
+        # Refresh from DB
+        super_villain = models.SuperVillain.objects.get(pk=super_villain.pk)
+
+        self.assertEqual(super_villain.stats['strength'], 100)
+        self.assertEqual(super_villain.stats['defence'], 50)
+        self.assertEqual(dump_dict(super_villain.stats), dump_dict(stats))

--- a/annoying/tests/models.py
+++ b/annoying/tests/models.py
@@ -1,9 +1,11 @@
 from django.db import models
 from annoying.fields import AutoOneToOneField
+from annoying.fields import JSONField
 
 
 class SuperVillain(models.Model):
     name = models.CharField(max_length="20", default="Dr Horrible")
+    stats = JSONField(default=None, blank=True, null=True)
 
 
 class SuperHero(models.Model):


### PR DESCRIPTION
The issue was in `get_db_prep_save` that parent's method has to return
a dict instead of an str.

Resolves issue #48.