### PR TITLE
Remove JSON import workaround for unsupported Python/Django versions

### DIFF
--- a/annoying/decorators.py
+++ b/annoying/decorators.py
@@ -1,3 +1,5 @@
+import json
+
 from django.shortcuts import render, render_to_response
 from django import forms
 from django import VERSION as DJANGO_VERSION
@@ -6,12 +8,6 @@ from django.db.models import signals as signalmodule
 from django.http import HttpResponse
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
-
-# Try to be compatible with Django 1.5+.
-try:
-    import json
-except ImportError:
-    from django.utils import simplejson as json
 
 # Basestring no longer exists in Python 3
 try:

--- a/annoying/fields.py
+++ b/annoying/fields.py
@@ -1,3 +1,5 @@
+import json
+
 from django import VERSION
 
 from django.db import models
@@ -15,12 +17,6 @@ try:
     SOUTH = True
 except ImportError:
     SOUTH = False
-
-# Try to be compatible with Django 1.5+.
-try:
-    import json
-except ImportError:
-    from django.utils import simplejson as json
 
 # Basestring no longer exists in Python 3
 try:

--- a/annoying/tests/decorators.py
+++ b/annoying/tests/decorators.py
@@ -1,11 +1,8 @@
 """Tests for django-annoying's decorators"""
 
-from django.test import TestCase
+import json
 
-try:
-    import json
-except ImportError:
-    from django.utils import simplejson as json
+from django.test import TestCase
 
 
 class AJAXRequestTestCase(TestCase):


### PR DESCRIPTION
All versions of supported Python have the json module available. Don't need to
fallback to simplejson.