### PR TITLE
Pass on_delete to OneToOneField to handle Django warning

### DIFF
--- a/annoying/tests/models.py
+++ b/annoying/tests/models.py
@@ -10,4 +10,4 @@ class SuperVillain(models.Model):
 
 class SuperHero(models.Model):
     name = models.CharField(max_length="20", default="Captain Hammer")
-    mortal_enemy = AutoOneToOneField(SuperVillain, related_name='mortal_enemy')
+    mortal_enemy = AutoOneToOneField(SuperVillain, on_delete=models.CASCADE, related_name='mortal_enemy')


### PR DESCRIPTION
Fixes warning:

RemovedInDjango20Warning: on_delete will be a required arg for AutoOneToOneField in Django 2.0. Set it to models.CASCADE on models and in existing migrations if you want to maintain the current default behavior. See https://docs.djangoproject.com/en/1.10/ref/models/fields/#django.db.models.ForeignKey.on_delete