### PR TITLE
Introduce isort to consistently sort import order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,5 @@ install:
   - pip install -r requirements.txt
 before_script:
   - flake8
+  - isort --check-only --diff
 script: ./runtests.sh

--- a/annoying/decorators.py
+++ b/annoying/decorators.py
@@ -1,18 +1,16 @@
-from functools import wraps
 import json
 import os
 import warnings
+from functools import wraps
 
-from django.shortcuts import render, render_to_response
-from django import forms
-from django import VERSION as DJANGO_VERSION
-from django.template import RequestContext
-from django.db.models import signals as signalmodule
-from django.http import HttpResponse
+from django import VERSION as DJANGO_VERSION, forms
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
+from django.db.models import signals as signalmodule
+from django.http import HttpResponse
+from django.shortcuts import render, render_to_response
+from django.template import RequestContext
 from django.utils import six
-
 
 __all__ = ['render_to', 'signals', 'ajax_request', 'autostrip']
 

--- a/annoying/fields.py
+++ b/annoying/fields.py
@@ -1,14 +1,15 @@
 import json
 
+from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django.db.models import OneToOneField
 from django.db.transaction import atomic
-from django.core.serializers.json import DjangoJSONEncoder
+from django.utils import six
+
 try:
     from django.db.models.fields.related import SingleRelatedObjectDescriptor
 except ImportError:
     from django.db.models.fields.related_descriptors import ReverseOneToOneDescriptor as SingleRelatedObjectDescriptor
-from django.utils import six
 
 
 class AutoSingleRelatedObjectDescriptor(SingleRelatedObjectDescriptor):

--- a/annoying/functions.py
+++ b/annoying/functions.py
@@ -1,5 +1,5 @@
-from django.shortcuts import _get_queryset
 from django.conf import settings
+from django.shortcuts import _get_queryset
 
 
 def get_object_or_None(klass, *args, **kwargs):

--- a/annoying/middlewares.py
+++ b/annoying/middlewares.py
@@ -1,8 +1,8 @@
 import re
 
 from django.conf import settings
-from django.views.static import serve
 from django.shortcuts import redirect
+from django.views.static import serve
 
 from .exceptions import Redirect
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 -e .
 flake8
+isort

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,3 +15,12 @@ universal = 1
 
 [metadata]
 license_file = LICENSE.txt
+
+[isort]
+combine_as_imports = true
+default_section = THIRDPARTY
+include_trailing_comma = true
+known_first_party = annoying
+line_length = 79
+multi_line_output = 5
+not_skip = __init__.py

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
+from setuptools import setup
+
 from annoying import __version__
 
-from setuptools import setup
 setup(
     name="django-annoying",
     version=__version__,

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,9 +1,8 @@
-from json import loads, dumps
+from json import dumps, loads
 
 from django.db import models
 
-from annoying.fields import AutoOneToOneField
-from annoying.fields import JSONField
+from annoying.fields import AutoOneToOneField, JSONField
 
 
 class SuperVillain(models.Model):

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -2,8 +2,8 @@
 from __future__ import absolute_import
 
 from django.conf.urls import url
-from . import views
 
+from . import views
 
 urlpatterns = [
     url(r'^ajax-request/$', views.ajax_request_view),

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,11 +1,11 @@
 """Views for django-annoying's tests"""
 from __future__ import absolute_import
 
+import datetime
+
 from django.http import HttpResponse
 
 from annoying.decorators import ajax_request, render_to
-
-import datetime
 
 
 @ajax_request


### PR DESCRIPTION
Removes the need for contributors to give any thought to how to organize import statements. Can simply let the tools handle it instead.

Use same configuration as used by the Django project.

Add isort check to Travis configuration.