### PR TITLE
Officially deprecate signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ def foo(request, category):
 
 ### signals decorator
 
-Note: Django now [includes this by default](https://docs.djangoproject.com/en/1.5/topics/signals/#connecting-receiver-functions).
+Note: `signals` is deprecated and will be removed in a future version. Django now [includes this by default](https://docs.djangoproject.com/en/stable/topics/signals/#connecting-receiver-functions).
 
 ```python
 from annoying.decorators import signals

--- a/annoying/decorators.py
+++ b/annoying/decorators.py
@@ -1,6 +1,7 @@
 from functools import wraps
 import json
 import os
+import warnings
 
 from django.shortcuts import render, render_to_response
 from django import forms
@@ -123,6 +124,15 @@ class Signals(object):
         return self._connect(self._signals[name])
 
     def __call__(self, signal, **kwargs):
+        warnings.warn(
+            "django-annoying signals decorator is deprecated and will be "
+            "removed in a future version. Use Django's receiver decorator "
+            "instead. "
+            "https://docs.djangoproject.com/en/stable/topics/signals/#connecting-receiver-functions",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         def inner(func):
             signal.connect(func, **kwargs)
             return func


### PR DESCRIPTION
It duplicates Django functionality of receiver decorator:

https://docs.djangoproject.com/en/1.11/topics/signals/#connecting-receiver-functions

After a release, can remove the functionality.