### PR TITLE
fix AutoOneToOneField race condition

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -22,3 +22,12 @@ class Minion(models.Model):
 class SuperHero(models.Model):
     name = models.CharField(max_length=20, default="Captain Hammer")
     mortal_enemy = AutoOneToOneField(SuperVillain, on_delete=models.CASCADE, related_name='mortal_enemy')
+
+
+class SuperHeroUnmanaged(models.Model):
+    name = models.CharField(max_length=20, default="Captain Hammer")
+    mortal_enemy_id = models.IntegerField()
+
+    class Meta:
+        managed = False
+        db_table = 'tests_superhero'


### PR DESCRIPTION
I see sometimes `RelatedObjectDoesNotExist` in error tracker. So I found out that `get_or_create()` called in `AutoSingleRelatedObjectDescriptor` doesn't reset or update cache of related objects in case if object already exists.

The problem is:

- process 1 calls to `ReverseOneToOneDescriptor.__get__()` and it raises `RelatedObjectDoesNotExist`
- process 2 calls to `ReverseOneToOneDescriptor.__get__()` and it raises `RelatedObjectDoesNotExist`
- process 1 calls `related_model.objects.get_or_create()`, it creates an object and update cache
- process 2 calls `related_model.objects.get_or_create()`, it select an object from database
- process 1 calls to `ReverseOneToOneDescriptor.__get__()` and it returns object from cache
- process 2 calls to `ReverseOneToOneDescriptor.__get__()`, it finds `None` saved in cache and raises `RelatedObjectDoesNotExist`, that won't catched

The only solution I can find is to set cache directly instead of calling `super().__get__()` second time.
