### PR TITLE
test: add recent versions of Django and Python to test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: python
+dist: xenial
 cache: pip
 matrix:
   include:
@@ -11,6 +12,8 @@ matrix:
       env: DJANGO=1.11.0
     - python: 3.6
       env: DJANGO=1.11.0
+    - python: 3.7
+      env: DJANGO=1.11.0
     - python: pypy
       env: DJANGO=1.11.0
     - python: 3.4
@@ -19,6 +22,20 @@ matrix:
       env: DJANGO=2.0
     - python: 3.6
       env: DJANGO=2.0
+    - python: 3.7
+      env: DJANGO=2.0
+    - python: 3.5
+      env: DJANGO=2.1
+    - python: 3.6
+      env: DJANGO=2.1
+    - python: 3.7
+      env: DJANGO=2.1
+    - python: 3.5
+      env: DJANGO=2.2
+    - python: 3.6
+      env: DJANGO=2.2
+    - python: 3.7
+      env: DJANGO=2.2
 install:
   - pip install Django~=$DJANGO
   - pip install -r requirements.txt


### PR DESCRIPTION
Add Django versions 2.1 and 2.2 as well as Python 3.7 to the Travis CI config.

No code changes required.