### PR TITLE
Add Django 3.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,12 @@ matrix:
       env: DJANGO=2.2
     - python: 3.7
       env: DJANGO=2.2
+    - python: 3.6
+      env: DJANGO=3.0
+    - python: 3.7
+      env: DJANGO=3.0
+    - python: 3.8
+      env: DJANGO=3.0
 install:
   - pip install Django~=$DJANGO
   - pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -49,9 +49,10 @@ def foo(request):
 # equals to
 def foo(request):
     bar = Bar.object.all()
-    return render_to_response('template.html',
-                                {'bar': bar},
-                                context_instance=RequestContext(request))
+    return render(request,
+                  'template.html',
+                  {'bar': bar},
+                  context_instance=RequestContext(request))
 
 
 # 2. Template name as TEMPLATE item value in return dictionary
@@ -64,9 +65,10 @@ def foo(request, category):
 #equals to
 def foo(request, category):
     template_name = '%s.html' % category
-    return render_to_response(template_name,
-                                {'bar': bar},
-                                context_instance=RequestContext(request))
+    return render(request,
+                  template_name,
+                  {'bar': bar},
+                  context_instance=RequestContext(request))
 ```
 
 ### signals decorator

--- a/README.md
+++ b/README.md
@@ -49,10 +49,7 @@ def foo(request):
 # equals to
 def foo(request):
     bar = Bar.object.all()
-    return render(request,
-                  'template.html',
-                  {'bar': bar},
-                  context_instance=RequestContext(request))
+    return render(request, 'template.html', {'bar': bar})
 
 
 # 2. Template name as TEMPLATE item value in return dictionary
@@ -65,10 +62,7 @@ def foo(request, category):
 #equals to
 def foo(request, category):
     template_name = '%s.html' % category
-    return render(request,
-                  template_name,
-                  {'bar': bar},
-                  context_instance=RequestContext(request))
+    return render(request, template_name, {'bar': bar})
 ```
 
 ### signals decorator

--- a/annoying/decorators.py
+++ b/annoying/decorators.py
@@ -4,13 +4,12 @@ import warnings
 from functools import wraps
 
 import six
-from django import VERSION as DJANGO_VERSION, forms
+from django import forms
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import signals as signalmodule
 from django.http import HttpResponse
 from django.shortcuts import render
-from django.template import RequestContext
 
 __all__ = ['render_to', 'signals', 'ajax_request', 'autostrip']
 
@@ -21,8 +20,7 @@ def render_to(template=None, content_type=None):
     function.
 
     Template name can be decorator parameter or TEMPLATE item in returned
-    dictionary.  RequestContext always added as context instance.
-    If view doesn't return dict then decorator simply returns output.
+    dictionary.  If view doesn't return dict then decorator simply returns output.
 
     Parameters:
      - template: template name to use
@@ -39,10 +37,7 @@ def render_to(template=None, content_type=None):
     # equals to
     def foo(request):
         bar = Bar.object.all()
-        return render(request,
-                      'template.html',
-                      {'bar': bar},
-                      context_instance=RequestContext(request))
+        return render(request, 'template.html', {'bar': bar})
 
 
     # 2. Template name as TEMPLATE item value in return dictionary.
@@ -57,10 +52,7 @@ def render_to(template=None, content_type=None):
     #equals to
     def foo(request, category):
         template_name = '%s.html' % category
-        return render(request,
-                      template_name,
-                      {'bar': bar},
-                      context_instance=RequestContext(request))
+        return render(request, template_name, {'bar': bar})
 
     """
     def renderer(function):
@@ -73,15 +65,8 @@ def render_to(template=None, content_type=None):
             if tmpl is None:
                 template_dir = os.path.join(*function.__module__.split('.')[:-1])
                 tmpl = os.path.join(template_dir, function.func_name + ".html")
-            # Explicit version check to avoid swallowing other exceptions
-            if DJANGO_VERSION >= (1, 9):
-                return render(request, tmpl, output,
-                              content_type=content_type)
-            else:
-                return render(request,
-                              tmpl, output,
-                              context_instance=RequestContext(request),
-                              content_type=content_type)
+            return render(request, tmpl, output,
+                          content_type=content_type)
         return wrapper
     return renderer
 

--- a/annoying/decorators.py
+++ b/annoying/decorators.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import signals as signalmodule
 from django.http import HttpResponse
-from django.shortcuts import render, render_to_response
+from django.shortcuts import render
 from django.template import RequestContext
 from django.utils import six
 
@@ -17,7 +17,7 @@ __all__ = ['render_to', 'signals', 'ajax_request', 'autostrip']
 
 def render_to(template=None, content_type=None):
     """
-    Decorator for Django views that sends returned dict to render_to_response
+    Decorator for Django views that sends returned dict to render
     function.
 
     Template name can be decorator parameter or TEMPLATE item in returned
@@ -39,9 +39,10 @@ def render_to(template=None, content_type=None):
     # equals to
     def foo(request):
         bar = Bar.object.all()
-        return render_to_response('template.html',
-                                  {'bar': bar},
-                                  context_instance=RequestContext(request))
+        return render(request,
+                      'template.html',
+                      {'bar': bar},
+                      context_instance=RequestContext(request))
 
 
     # 2. Template name as TEMPLATE item value in return dictionary.
@@ -56,9 +57,10 @@ def render_to(template=None, content_type=None):
     #equals to
     def foo(request, category):
         template_name = '%s.html' % category
-        return render_to_response(template_name,
-                                  {'bar': bar},
-                                  context_instance=RequestContext(request))
+        return render(request,
+                      template_name,
+                      {'bar': bar},
+                      context_instance=RequestContext(request))
 
     """
     def renderer(function):
@@ -76,9 +78,10 @@ def render_to(template=None, content_type=None):
                 return render(request, tmpl, output,
                               content_type=content_type)
             else:
-                return render_to_response(tmpl, output,
-                                          context_instance=RequestContext(request),
-                                          content_type=content_type)
+                return render(request,
+                              tmpl, output,
+                              context_instance=RequestContext(request),
+                              content_type=content_type)
         return wrapper
     return renderer
 

--- a/annoying/decorators.py
+++ b/annoying/decorators.py
@@ -3,6 +3,7 @@ import os
 import warnings
 from functools import wraps
 
+import six
 from django import VERSION as DJANGO_VERSION, forms
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
@@ -10,7 +11,6 @@ from django.db.models import signals as signalmodule
 from django.http import HttpResponse
 from django.shortcuts import render
 from django.template import RequestContext
-from django.utils import six
 
 __all__ = ['render_to', 'signals', 'ajax_request', 'autostrip']
 

--- a/annoying/fields.py
+++ b/annoying/fields.py
@@ -1,6 +1,7 @@
 import json
 
 import django
+import six
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django.db.models import OneToOneField
@@ -8,7 +9,6 @@ from django.db.models.fields.related_descriptors import (
     ReverseOneToOneDescriptor,
 )
 from django.db.transaction import atomic
-from django.utils import six
 
 
 def dumps(value):

--- a/annoying/utils.py
+++ b/annoying/utils.py
@@ -16,7 +16,7 @@ class HttpResponseReload(HttpResponse):
                 return HttpResponseReload(request)
         else:
             form = CommentForm()
-        return render_to_response('some_template.html', {'form': form})
+        return render(request, 'some_template.html', {'form': form})
     """
     status_code = 302
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     license="BSD",
     keywords="django",
     url="https://github.com/skorokithakis/django-annoying",
-    install_requires=['Django >= 1.11'],
+    install_requires=['Django >= 1.11', 'six'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Framework :: Django',


### PR DESCRIPTION
Function `render_ro_response()` and package `django.utils.six` have been removed in 3.0:

- use django.utils.render() instead of render_ro_response()
- use six package instead of django.utils.six
- add django 3.0 to Travis CI matrix

See backward-incompatible [changes](https://docs.djangoproject.com/en/3.0/releases/3.0/#backwards-incompatible-changes-in-3-0) in 3.0.