### PR TITLE
fix: expose type annotations through py.typed file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,4 +63,5 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
     ],
+    package_data={"annoying": ["py.typed"]},
 )


### PR DESCRIPTION
### What & why

Add `py.typed` file to allow types to be introspected by the library client's.
For example some types have been added in this PR https://github.com/skorokithakis/django-annoying/pull/104 but won't be usable by mypy (for example) if they are not exposed through this [^file]

[^file]: More information https://typing.readthedocs.io/en/latest/spec/distributing.html#packaging-type-information